### PR TITLE
joystick: support 80's game controllers

### DIFF
--- a/src/gui-sdl/sdlgui.c
+++ b/src/gui-sdl/sdlgui.c
@@ -1330,12 +1330,28 @@ int SDLGui_DoDialog(SGOBJ *dlg, SDL_Event *pEventOut, bool KeepCurrentObject)
 				}
 				break;
 
+			 case SDL_JOYHATMOTION:
+				if (sdlEvent.jhat.value & SDL_HAT_LEFT)
+					retbutton = SDLGui_HandleShortcut(dlg, SG_SHORTCUT_LEFT);
+				else if (sdlEvent.jhat.value & SDL_HAT_RIGHT)
+					retbutton = SDLGui_HandleShortcut(dlg, SG_SHORTCUT_RIGHT);
+				if (sdlEvent.jhat.value & SDL_HAT_UP)
+				{
+					SDLGui_RemoveFocus(dlg, focused);
+					focused = SDLGui_FocusNext(dlg, focused, -1);
+				}
+				else if (sdlEvent.jhat.value & SDL_HAT_DOWN)
+				{
+					SDLGui_RemoveFocus(dlg, focused);
+					focused = SDLGui_FocusNext(dlg, focused, +1);
+				}
+				break;
+
 			 case SDL_JOYBUTTONDOWN:
 				retbutton = SDLGui_HandleSelection(dlg, focused, focused);
 				break;
 
 			 case SDL_JOYBALLMOTION:
-			 case SDL_JOYHATMOTION:
 			 case SDL_MOUSEMOTION:
 				break;
 

--- a/src/joy.c
+++ b/src/joy.c
@@ -200,9 +200,20 @@ void Joy_UnInit(void)
  */
 static bool Joy_ReadJoystick(int nSdlJoyID, JOYREADING *pJoyReading)
 {
+	unsigned hat = SDL_JoystickGetHat(sdlJoystick[nSdlJoyID], 0);
+
 	/* Joystick is OK, read position from the configured joystick axis */
 	pJoyReading->XPos = SDL_JoystickGetAxis(sdlJoystick[nSdlJoyID], pJoyReading->XAxisID);
 	pJoyReading->YPos = SDL_JoystickGetAxis(sdlJoystick[nSdlJoyID], pJoyReading->YAxisID);
+	/* Similarly to other emulators that support hats, override axis readings with hats */
+	if (hat & SDL_HAT_LEFT)
+		pJoyReading->XPos = -32768;
+	if (hat & SDL_HAT_RIGHT)
+		pJoyReading->XPos = 32767;
+	if (hat & SDL_HAT_UP)
+		pJoyReading->YPos = -32768;
+	if (hat & SDL_HAT_DOWN)
+		pJoyReading->YPos = 32767;
 	/* Sets bit #0 if button #1 is pressed: */
 	pJoyReading->Buttons = SDL_JoystickGetButton(sdlJoystick[nSdlJoyID], 0);
 	/* Sets bit #1 if button #2 is pressed: */


### PR DESCRIPTION
Recently I've bought USB adapter for 80s Atari-compatible joysticks (with DB9 connectors). It is recognized as 'hat' by SDL library joystick routines. Other emulators (fuse, fs-uae) can read this (and overwrite axes readings with hat readings making excellent gaming experience) while hatari read axes only. This patch fixes the issue, giving amazing 80s-like gaming experiences for this amazing emulator.
