### PR TITLE
Fix garbage graphics by clearing the whole render area

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -444,6 +444,9 @@ bool Screen_SetSDLVideoSize(int width, int height, int bitdepth, bool bForceChan
 			exit(1);
 		}
 
+		SDL_SetRenderDrawColor(sdlRenderer, 0, 0, 0, 255);
+		SDL_RenderClear(sdlRenderer);
+
 		if (bInFullScreen)
 			SDL_RenderSetLogicalSize(sdlRenderer, width, height);
 


### PR DESCRIPTION
Garbage graphics can be observed to the left and right of for example
a 1920x1200 screen resolution, when switching to fullscreen.