### PR TITLE
Add SDL_RenderPresent to full screen force to black

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -444,8 +444,10 @@ bool Screen_SetSDLVideoSize(int width, int height, int bitdepth, bool bForceChan
 			exit(1);
 		}
 
+		/* Force to black to stop side bar artifacts on 16:9 monitors. */
 		SDL_SetRenderDrawColor(sdlRenderer, 0, 0, 0, 255);
 		SDL_RenderClear(sdlRenderer);
+		SDL_RenderPresent(sdlRenderer);
 
 		if (bInFullScreen)
 			SDL_RenderSetLogicalSize(sdlRenderer, width, height);


### PR DESCRIPTION
Force to black in loop to fix 5K amdgpu fullscreen sidebar corruption. I observed the issue in 5K 5120x2880 on Fedora 30 and Ubuntu 19.04 with AMD RX580 running Xorg amdgpu driver.

The change in https://github.com/hatari/hatari/pull/6 was enough to fix sidebar corruption in resolutions up to and including 4K on my machine,  but I needed this loop workaround to force multiple clears to stop similar garbage appearing in sidebars when running in 5K mode. 

I also needed to enable VSync in the hatari screen options for the loop to have any effect. VSync on is own wasn't enough to fix the issue, needed Vsync and the loop.



