### PR TITLE
Documentation: Filter losetup output by disk image name when getting the loopdevice name

### DIFF
--- a/doc/manual.html
+++ b/doc/manual.html
@@ -2457,7 +2457,7 @@ $ su
 # image="hd.img"; mountdir="hd"
 # start=$(parted $image unit s print | awk '/ 1 /{print $2}' | tr -d s)
 # losetup -f $image -o $((512*$start))
-# loop=$(losetup -a | tail -1 | cut -d: -f1)
+# loop=$(losetup -a | grep $image | cut -d: -f1)
 # mkdir -p $mountdir
 # mount -t msdos $loop $mountdir
 </pre>


### PR DESCRIPTION
This fixes the following problem:
Ex: on my system I have
losetup -a
/dev/loop1: [2050]:4587550 (/var/lib/snapd/snaps/spotify_36.snap)
/dev/loop4: [2050]:4714240 (/var/lib/snapd/snaps/core_7917.snap)
/dev/loop2: [2050]:4609173 (/var/lib/snapd/snaps/spotify_35.snap)
/dev/loop0: [2052]:16909653 (/home/manu/Projects/emul/atari/hard_disk_images/ahdi-64M.img), offset 1024
/dev/loop3: [2050]:4714239 (/var/lib/snapd/snaps/core_7713.snap)

The script would then pick loop3 instead of loop0.

I don't know how losetup sorts the loop device list. Filtering by disk image name is in anycase the safer bet !