### PR TITLE
Fix "[ffmpeg/video] Invalid PNG signature 0x89504E470D0A1A"

### DIFF
--- a/doc/compatibility.html
+++ b/doc/compatibility.html
@@ -1957,6 +1957,18 @@ href="http://www.umich.edu/~archive/atari/Games/Space/zero_5.zip">Zero-5</a><br 
       <td>&nbsp;</td>
     </tr>
     <tr>
+      <td>SMFX:
+      <a href="https://www.pouet.net/prod.php?which=81777">Motus</a></td>
+      <td>2.2</td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
+      <td>SMFX & KÜA:
+      <a href="https://www.pouet.net/prod.php?which=84091">We Accidentally Released</a></td>
+      <td>2.2</td>
+      <td>&nbsp;</td>
+    </tr>
+    <tr>
       <td>Syntax:
       <a href="http://pouet.net/prod.php?which=17044">Reanimation</a></td>
       <td>before 1.0</td>

--- a/doc/emutos.txt
+++ b/doc/emutos.txt
@@ -333,7 +333,6 @@ Demos:
 - Breath (by Mystic Bytes)
 - Calimer-o-demo (by Oxygene)
 - Charts Compilation (by Next)
-- City Frames (by DHS)
 - Coast II Coast (by Sector One, 4kB intro)
 - Coolism (music disk, by Effect)
 - Crisis (by Joska)
@@ -853,6 +852,7 @@ Demos:
 - CD-player (by Light)
 - Cernit Trandafir (by DHS)
 - Circus BackSTage (by BlaBLa)
+- City Frames (by DHS)
 - Core Flakes (by New Core)
 - Devotion (by Excellence in Art)
 - Dynamite (by Unit 17)
@@ -926,8 +926,9 @@ Demos:
 - Unbeatable (by Masters of Electric City)
 - Vision (by POV)
 - Vulgar Display of Power (by Extream)
+- We Accidentally Released (by SMFX & KÜA)
 - We Were @ STNICCC 2015 (by Oxygene)
-  - Reset screen colors are wrong and scrolltext skewed
+  - Reset screen scroll text colors are wrong
 - Wonderful World (by Paradox)
 - XiTEC Presentation (by Omega)
 - Xmas 2004 (by Paradox)

--- a/doc/manual.html
+++ b/doc/manual.html
@@ -81,7 +81,6 @@ and demos. Of course you can run normal GEM applications with Hatari, too.
   <li>Printer port emulation on hardware level (print to file)</li>
   <li>RS232 emulation</li>
   <li>MIDI input/output/through emulation</li>
-  <li>Mega ST(E) real time clock (for Mega-ST and Mega-STE mode)</li>
   <li>IKBD emulation (keyboard, mouse and joystick) with custom
     keyboard mapping</li>
   <li>joystick emulation via cursor keys and joystick emulation via a
@@ -118,10 +117,16 @@ and demos. Of course you can run normal GEM applications with Hatari, too.
   <li>STE joypads</li>
   <li>TOS versions 1.06, 1.62, 2.05 and 2.06 (and EmuTOS) can be used in STE mode.</li>
 </ul>
-<p>
-Hatari can also emulate a Mega-STE, which had slightly different hardware
-compared to a normal STE (like a built-in real time clock chip).
-</p>
+
+<h4>Mega ST/STE hardware emulation</h4>
+<p>There is support for following additional features in Mega ST/STE
+and later HW:</p>
+<ul>
+  <li>Builtin real time clock</li>
+  <li>Experimental Mega STE/TT/Falcon SCC channel B serial port support (incomplete)</li>
+  <li>TOS versions 1.02, 1.04 and 2.06 (and EmuTOS) can be used in Mega ST mode, and
+      TOS versions 2.05 and 2.06 (and EmuTOS) in Mega STE mode.</li>
+</ul>
 
 <h4>TT hardware emulation</h4>
 <p>There is support for following additional TT features:</p>
@@ -137,7 +142,8 @@ compared to a normal STE (like a built-in real time clock chip).
 <p>There is support for following additional Falcon features:</p>
 <ul>
   <li>Partial Videl and Videl borders emulation for all Falcon screen modes</li>
-  <li>Aspect correction and scaling of small resolutions by an integer factor</li>
+  <li>Aspect correction and scaling of small resolutions by an integer factor
+      (SDL1), or to any size (SDL2)</li>
   <li>STE/Falcon palette switching and shifter</li>
   <li>Mono/RGB/VGA/TV monitor types</li>
   <li>DSP co-processor emulation</li>
@@ -150,7 +156,8 @@ compared to a normal STE (like a built-in real time clock chip).
   <li>Experimental NCR5380 SCSI emulation for hard drive support (incomplete)</li>
   <li>TOS versions 4.00, 4.02, 4.04 and 4.92 (and EmuTOS) can be used in Falcon
       mode. There is also experimental support for TOS 2.07 (the "Sparrow"-TOS),
-      but it is not recommended to use it</li>
+      and for <a href="m68k-linux-for-hatari.txt">Linux</a></li>, but they are
+      not recommended for use yet
 </ul>
 <p>
 Both TT and Falcon emulation support NVRAM for persistent OS configuration
@@ -1436,10 +1443,9 @@ certain games. In some other games, it gets worse if you enable this option.</p>
  the machine type which you have selected in the "System options"
  dialog. In ST and STE mode, you can choose between monochrome mode
  (select "Mono") and color mode (select one of the other monitor types).
- Note that when you select "TV" and use zoomed low resolution or
- switch to ST medium resolution, you will get a TV-like screen rendering
- which is a little bit faster but darker compared to the normal "RGB"
- monitor mode. Switching between mono and a color monitor acts like a monitor
+ When you select "TV" and use zoomed low resolution or switch to ST
+ medium, you get TV-like screen with half the intensity on every other
+ line. Switching between mono and a color monitor acts like a monitor
  switch on a real ST - so beware, this will reboot your emulated system!<br />
  In TT mode, you can only choose between TT-high resolution ("Mono")
  and normal modes (select one of the other monitor types).

--- a/doc/release-notes.txt
+++ b/doc/release-notes.txt
@@ -59,9 +59,13 @@ Emulator:
     (slows profiling of addresses with symbols)
   - All profiler outputs have now reasonable limits
     (so that they don't flood console)
-  - Fix: profile post-processor exception (with symbol address aliases)
+  - Fix: exception in profile post-processor script
+    (with symbol address aliases)
 - Debugger:
   - Fix: CPU disassembly trace output doesn't go to specified trace file
+  - "symbols resident" option replaced with "symbols autoload"
+    option which be used to completely disable automatic symbol
+    loading and unloading for programs run through the GEMDOS HD
   - Trace flags can be added and removed instead of needing
     to always specify all the relevant ones:
     --trace os_base,aes, trace +xbios,bios, trace -bios,-aes
@@ -79,7 +83,9 @@ Building:
 
 Documentation:
 - Up to date documentation provided at: https://hatari.tuxfamily.org/doc/
-- m68k-linux-for-hatari.txt document on how to run Linux under Hatari
+- New m68k-linux-for-hatari.txt document on how to run Linux under Hatari
+- Debugging and profiling information is split from manual.html to
+  a separate debugger.html file
 - Minor improvements
 
 Fixed programs:

--- a/src/avi_record.c
+++ b/src/avi_record.c
@@ -965,11 +965,6 @@ static bool	Avi_RecordVideoStream_PNG ( RECORD_AVI_PARAMS *pAviParams )
 		pAviParams->CropLeft , pAviParams->CropRight , pAviParams->CropTop , pAviParams->CropBottom );
 	if ( SizeImage <= 0 )
 		goto png_error;
-	if ( SizeImage & 1 )
-	{
-		SizeImage++;							/* add an extra '\0' byte to get an even size */
-		fputc ( '\0' , pAviParams->FileOut );				/* next chunk must be aligned on 16 bits boundary */
-	}
 
 	/* Update the size of the video chunk */
 	Avi_StoreU32 ( TempSize , SizeImage );

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -66,7 +66,7 @@ static const struct Config_Tag configs_Debugger[] =
 	{ "nExceptionDebugMask", Int_Tag, &ConfigureParams.Debugger.nExceptionDebugMask },
 	{ "nDisasmOptions", Int_Tag, &ConfigureParams.Debugger.nDisasmOptions },
 	{ "bDisasmUAE", Bool_Tag, &ConfigureParams.Debugger.bDisasmUAE },
-	{ "bSymbolsResident", Bool_Tag, &ConfigureParams.Debugger.bSymbolsResident },
+	{ "bSymbolsAutoLoad", Bool_Tag, &ConfigureParams.Debugger.bSymbolsAutoLoad },
 	{ "bMatchAllSymbols", Bool_Tag, &ConfigureParams.Debugger.bMatchAllSymbols },
 	{ NULL , Error_Tag, NULL }
 };
@@ -663,7 +663,7 @@ void Configuration_SetDefault(void)
 	ConfigureParams.Debugger.nExceptionDebugMask = DEFAULT_EXCEPTIONS;
 	/* external one has nicer output, but isn't as complete as UAE one */
 	ConfigureParams.Debugger.bDisasmUAE = false;
-	ConfigureParams.Debugger.bSymbolsResident = false;
+	ConfigureParams.Debugger.bSymbolsAutoLoad = true;
 	ConfigureParams.Debugger.bMatchAllSymbols = false;
 	ConfigureParams.Debugger.nDisasmOptions = Disasm_GetOptions();
 

--- a/src/includes/configuration.h
+++ b/src/includes/configuration.h
@@ -35,8 +35,8 @@ typedef struct
   int nExceptionDebugMask;
   int nDisasmOptions;
   bool bDisasmUAE;
-  /* load symbols immediately on program start, and keep them after its termination */
-  bool bSymbolsResident;
+  /* load and free symbols for GEMDOS HD loaded programs automatically */
+  bool bSymbolsAutoLoad;
   /* whether to match all symbols or just types relevant for given command */
   bool bMatchAllSymbols;
 } CNF_DEBUGGER;


### PR DESCRIPTION
The attempt to align PNG chunk sizes with 16-bit word boundaries causes problems when replaying the resulting AVI file using mpv:

```
Error while decoding frame!
[ffmpeg/video] png: Invalid PNG signature 0x89504E470D0A1A.
```

Removing the offending alignment code solves this problem.

Additionally, but unrelated to this change, there is an issue with audio and video synchronisation, that is also problematic with the BMP coder.