### PR TITLE
Visual Studio compilation fix

### DIFF
--- a/src/includes/vs-fix.h
+++ b/src/includes/vs-fix.h
@@ -7,6 +7,8 @@
 #ifndef VS_FIX_H
 #define VS_FIX_H
 
+#include <windows.h> /* For getting SDK version */
+
 // Stop Visual Studio complaining
 #define _CRT_SECURE_NO_WARNINGS	/* Insecure strcpy etc. */
 #pragma warning (disable:4018)	/* signed / unsigned mismatch */
@@ -19,7 +21,9 @@
 #pragma warning (disable:4800)	/* Performance Warning on Conversion of bool to int */
 #pragma warning (disable:4996)	/* Unsafe functions */
 
+#ifndef NTDDI_WIN10_19H1 /* this makes compilation error in newer SDK's and obviously is not needed anymore (at least from SDK NTDDI_WIN10_19H1, but maybe even from older - not tested) */
 #undef _DEBUG	/* Visual Studio is doing some macro redefinition otherwise */
+#endif
 
 typedef unsigned short mode_t;
 

--- a/src/includes/vs-fix.h
+++ b/src/includes/vs-fix.h
@@ -7,6 +7,7 @@
 #ifndef VS_FIX_H
 #define VS_FIX_H
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h> /* For getting SDK version */
 
 // Stop Visual Studio complaining


### PR DESCRIPTION
This removes #undef _DEBUG hack, because obviously it is not needed anymore and it is root cause of compilation error on newer VS with newer SDK's.
At least from SDK WIN10 19H1 this causes compile issue, but maybe even from older - not tested.

After this compilation works fine with VS2019 (+ SDK WIN10 19H1)