### PR TITLE
VS CI build fix

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -59,3 +59,37 @@ cygwin_task:
     - C:\tools\cygwin\bin\bash.exe -lc "cd '%cd%' ; make -j4"
   test_script:
     - C:\tools\cygwin\bin\bash.exe -lc "cd '%cd%' ; ctest -j4"
+
+visualstudio_task:
+  windows_container:
+    image: cirrusci/windowsservercore:2019
+    cpu: 4
+    memory: 4G
+  choco_cache:
+    folder: '%temp%\chocolatey'
+  install_script:
+    - choco install -y --no-progress cmake --install-arguments="ADD_CMAKE_TO_PATH=System"
+    - choco install -y --no-progress visualstudio2019community
+        visualstudio2019-workload-vctools
+    # Keep the log and temporary files out of the cache:
+    - del %temp%\chocolatey\*.log
+    - del %temp%\chocolatey\*log.txt
+    - del %temp%\chocolatey\*.tmp
+    - del %temp%\chocolatey\windowssdk\*.log
+    - del %temp%\chocolatey\VSLogs\*.svclog
+    # Install the required libraries and headers:
+    - curl -O "https://www.libsdl.org/release/SDL2-devel-2.0.14-VC.zip"
+    - powershell -command "Expand-Archive -Force '%cd%\SDL2-devel-2.0.14-VC.zip' '%cd%'"
+    - curl -O https://raw.githubusercontent.com/barrysteyn/scrypt-windows/master/win/include/unistd.h
+    - curl -O https://raw.githubusercontent.com/tronkko/dirent/master/include/dirent.h
+    - echo // > getopt.h
+  script:
+    - refreshenv
+    - cmake -G "Visual Studio 16 2019" -A X64 -DCMAKE_BUILD_TYPE="Release"
+        -DSDL2_INCLUDE_DIR="%cd%\SDL2-2.0.14\include"
+        -DSDL2_LIBRARY="%cd%\SDL2-2.0.14\lib\x64\SDL2.lib"
+        -DSDL2MAIN_LIBRARY="%cd%\SDL2-2.0.14\lib\x64\SDL2main.lib" .
+    - cmake --build . --verbose --target ALL_BUILD --config Release -j4
+  test_script:
+    - refreshenv
+    - ctest -C Release


### PR DESCRIPTION
Issue with the previous WIN server image with CMAKE was probably that it had already installed some parts of VS.
More robust solution should be to use a clean image and install everything by own (and this PR is doing that).
\+ changed VS2017 -> VS2019

PS: If it will broke in the future again I am ready to fix it :)