### PR TITLE
Add missing renames to python3

### DIFF
--- a/tools/atari-hd-image.sh
+++ b/tools/atari-hd-image.sh
@@ -33,8 +33,8 @@ PATH=/sbin:$PATH
 export PATH
 
 # check tools
-if [ -z "$(which mkdosfs)" ] || [ -z "$(which python)" ]; then
-	echo "ERROR: either mkdosfs or python tool missing!"
+if [ -z "$(which mkdosfs)" ] || [ -z "$(which python3)" ]; then
+	echo "ERROR: either mkdosfs or python3 missing!"
 	exit 1
 fi
 
@@ -147,7 +147,7 @@ echo "$step) Create DOS Master Boot Record / partition table..."
 # - http://en.wikipedia.org/wiki/File_Allocation_Table#Boot_Sector
 # For DOS MBR, the values are little endian.
 # -----------
-python << EOF
+python3 << EOF
 #!/usr/bin/env python3
 mbr = bytearray(512)
 


### PR DESCRIPTION
3ccc775f5 fixed the python script hashbangs, but inline python code was not yet covered