### PR TITLE
Add bGrabMouse to the configuration file

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -77,6 +77,7 @@ static const struct Config_Tag configs_Screen[] =
 	{ "nMonitorType", Int_Tag, &ConfigureParams.Screen.nMonitorType },
 	{ "nFrameSkips", Int_Tag, &ConfigureParams.Screen.nFrameSkips },
 	{ "bFullScreen", Bool_Tag, &ConfigureParams.Screen.bFullScreen },
+	{ "bGrabMouse", Bool_Tag, &ConfigureParams.Screen.bGrabMouse },
 	{ "bKeepResolution", Bool_Tag, &ConfigureParams.Screen.bKeepResolution },
 	{ "bResizable", Bool_Tag, &ConfigureParams.Screen.bResizable },
 	{ "bAllowOverscan", Bool_Tag, &ConfigureParams.Screen.bAllowOverscan },

--- a/src/includes/configuration.h
+++ b/src/includes/configuration.h
@@ -294,6 +294,7 @@ typedef struct
   bool bShowStatusbar;
   bool bShowDriveLed;
   bool bMouseWarp;
+  bool bGrabMouse;
   bool bCrop;
   bool bForceMax;
   bool bUseExtVdiResolutions;

--- a/src/screen.c
+++ b/src/screen.c
@@ -746,6 +746,7 @@ void Screen_Init(void)
 
 	/* Set initial window resolution */
 	bInFullScreen = ConfigureParams.Screen.bFullScreen;
+	bGrabMouse = ConfigureParams.Screen.bGrabMouse;
 	Screen_ChangeResolution(false);
 	ScreenDrawFunctionsNormal[ST_HIGH_RES] = Screen_ConvertHighRes;
 


### PR DESCRIPTION
Hi Hatari devs,

Here is a very small patch to add bGrabMouse to the configuration file.
When set to TRUE, the mouse cursor is automatically grabbed at startup (equivalent to pressing AltGr+M).