### PR TITLE
Fixes for broken Lowpass Filter

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -252,15 +252,6 @@ void Audio_SetOutputAudioFreq(int nNewFrequency)
 			Audio_Init();
 		}
 	}
-
-	/* Apply YM2149 C10 low pass filter ? (except if forced to NONE) */
-	if ( YM2149_LPF_Filter != YM2149_LPF_FILTER_NONE )
-	{
-		if ( Config_IsMachineST() && nAudioFrequency >= 40000 )
-			YM2149_LPF_Filter = YM2149_LPF_FILTER_LPF_STF;
-		else
-			YM2149_LPF_Filter = YM2149_LPF_FILTER_PWM;
-	}
 }
 
 

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -272,6 +272,8 @@ static const struct Config_Tag configs_Sound[] =
 	{ "nSdlAudioBufferSize", Int_Tag, &ConfigureParams.Sound.SdlAudioBufferSize },
 	{ "szYMCaptureFileName", String_Tag, ConfigureParams.Sound.szYMCaptureFileName },
 	{ "YmVolumeMixing", Int_Tag, &ConfigureParams.Sound.YmVolumeMixing },
+	{ "YmLpf", Int_Tag, &ConfigureParams.Sound.YmLpf },
+	{ "YmHpf", Int_Tag, &ConfigureParams.Sound.YmHpf },
 	{ NULL , Error_Tag, NULL }
 };
 
@@ -732,6 +734,8 @@ void Configuration_SetDefault(void)
 	                 psWorkingDir, "hatari", "wav");
 	ConfigureParams.Sound.SdlAudioBufferSize = 0;
 	ConfigureParams.Sound.YmVolumeMixing = YM_TABLE_MIXING;
+	ConfigureParams.Sound.YmLpf = YM2149_LPF_FILTER_IIR;
+	ConfigureParams.Sound.YmHpf = YM2149_HPF_FILTER_IIR;
 
 	/* Set defaults for Rom */
 	File_MakePathBuf(ConfigureParams.Rom.szTosImageFileName,
@@ -863,6 +867,8 @@ void Configuration_Apply(bool bReset)
 		ConfigureParams.Sound.YmVolumeMixing = YM_TABLE_MIXING;
 
 	YmVolumeMixing = ConfigureParams.Sound.YmVolumeMixing;
+	YM2149_LPF_Filter = ConfigureParams.Sound.YmLpf;
+	YM2149_HPF_Filter = ConfigureParams.Sound.YmHpf;
 	Sound_SetYmVolumeMixing();
 
 	/* Falcon : update clocks values if sound freq changed  */

--- a/src/includes/configuration.h
+++ b/src/includes/configuration.h
@@ -74,6 +74,8 @@ typedef struct
   int SdlAudioBufferSize;
   char szYMCaptureFileName[FILENAME_MAX];
   int YmVolumeMixing;
+  int YmLpf;
+  int YmHpf;
 } CNF_SOUND;
 
 

--- a/src/includes/sound.h
+++ b/src/includes/sound.h
@@ -51,6 +51,7 @@ extern int	YmVolumeMixing;
 #define		YM2149_LPF_FILTER_NONE			0
 #define		YM2149_LPF_FILTER_LPF_STF		1
 #define		YM2149_LPF_FILTER_PWM			2
+#define		YM2149_LPF_FILTER_IIR			3
 extern int	YM2149_LPF_Filter;
 
 #define		YM2149_HPF_FILTER_NONE			0

--- a/src/sound.c
+++ b/src/sound.c
@@ -117,7 +117,7 @@
 /* 2008/10/26	[NP]	Correctly save/restore all necessary variables in		*/
 /*			Sound_MemorySnapShot_Capture.					*/
 /* 2008/11/23	[NP]	Clean source, remove old sound core.				*/
-/* 2011/11/03	[DS]	Stereo DC filtering which accounts for DMA sound.               */
+/* 2011/11/03	[DS]	Stereo DC filtering which accounts for DMA sound.		*/
 /* 2017/06/xx	[NP]	New cycle exact emulation method, all counters are incremented	*/
 /*			using a simulated freq of 250 kHz. Some undocumented cases	*/
 /*			where also measured on real STF to improve accuracy.		*/
@@ -125,6 +125,8 @@
 /*			downsampling of the internal 250 kHz sound buffer.		*/
 /* 2021/07/23	[NP]	Default to 250 kHz cycle accurate emulation and remove older	*/
 /*			rendering and associated functions/variables.			*/
+/* 2023/08/06	[BS]	Restore lowpass filter to audio samplerate, had been at 250 khz */
+/*			incorrectly. Add cleaner IIR lowpass filter default.		*/
 
 
 const char Sound_fileid[] = "Hatari sound.c";
@@ -285,7 +287,7 @@ uint8_t		SoundRegs[ 14 ];
 
 int		YmVolumeMixing = YM_TABLE_MIXING;
 
-int		YM2149_LPF_Filter = YM2149_LPF_FILTER_PWM;
+int		YM2149_LPF_Filter = YM2149_LPF_FILTER_IIR;
 // int		YM2149_LPF_Filter = YM2149_LPF_FILTER_NONE;	/* For debug */
 int		YM2149_HPF_Filter = YM2149_HPF_FILTER_IIR;
 // int		YM2149_HPF_Filter = YM2149_HPF_FILTER_NONE;	/* For debug */
@@ -338,6 +340,7 @@ static CLOCKS_CYCLES_STRUCT	YM2149_ConvertCycles_250;
 
 static ymsample	LowPassFilter		(ymsample x0);
 static ymsample	PWMaliasFilter		(ymsample x0);
+static ymsample	IIRLowPassFilter	(ymsample x0);
 
 static void	interpolate_volumetable	(ymu16 volumetable[32][32][32]);
 
@@ -486,7 +489,20 @@ static ymsample	PWMaliasFilter(ymsample x0)
 	return y0;
 }
 
-
+/**
+ * A simpler IIR LPF filter which doesn't have the asymmterical
+ * push-pull distortion of the filters above, making it much cleaner sounding.
+ * Cutoff frequency is the same as the pull up of LowPassFilter above.
+ * fc = 7586.1 Hz (44.1 KHz), fc = 8257.0 Hz (48 KHz)
+ * 2023/08/06 Brad Smith.
+ */
+static ymsample	IIRLowPassFilter(ymsample x0)
+{
+	static	yms32 y0 = 0, x1 = 0;
+	y0 = (3*(x0 + x1) + (y0<<1)) >> 3;
+	x1 = x0;
+	return y0;
+}
 
 /*--------------------------------------------------------------*/
 /* Build the volume conversion table used to simulate the	*/
@@ -1106,12 +1122,6 @@ static void	YM2149_DoSamples_250 ( int SamplesToGenerate_250 )
 
 		sample = ymout5[ Tone3Voices ];			/* 16 bits signed value */
 
-		/* Apply low pass filter ? */
-		if ( YM2149_LPF_Filter == YM2149_LPF_FILTER_LPF_STF )
-			sample = LowPassFilter ( sample );
-		else if ( YM2149_LPF_Filter == YM2149_LPF_FILTER_PWM )
-			sample = PWMaliasFilter ( sample );
-
 		/* Store sample */
 		YM_Buffer_250[ pos ] = sample;
 		pos = ( pos + 1 ) & YM_BUFFER_250_SIZE_MASK;
@@ -1385,17 +1395,23 @@ static ymsample	YM2149_Next_Resample_Weighted_Average_2 ( void )
 
 static ymsample	YM2149_NextSample_250 ( void )
 {
-	if ( YM2149_Resample_Method == YM2149_RESAMPLE_METHOD_WEIGHTED_AVERAGE_2 )
-		return YM2149_Next_Resample_Weighted_Average_2 ();
-
-	else if ( YM2149_Resample_Method == YM2149_RESAMPLE_METHOD_NEAREST )
-		return YM2149_Next_Resample_Nearest ();
-
-	else if ( YM2149_Resample_Method == YM2149_RESAMPLE_METHOD_WEIGHTED_AVERAGE_N )
-		return YM2149_Next_Resample_Weighted_Average_N ();
-
-	else
-		return 0;
+	ymsample sample = 0;
+	switch (YM2149_Resample_Method)
+	{
+		case YM2149_RESAMPLE_METHOD_NEAREST:            sample = YM2149_Next_Resample_Nearest();            break;
+		case YM2149_RESAMPLE_METHOD_WEIGHTED_AVERAGE_2: sample = YM2149_Next_Resample_Weighted_Average_2(); break;
+		case YM2149_RESAMPLE_METHOD_WEIGHTED_AVERAGE_N: sample = YM2149_Next_Resample_Weighted_Average_N(); break;
+		default: break;
+	}
+	switch (YM2149_LPF_Filter)
+	{
+		default:
+		case YM2149_LPF_FILTER_NONE:                                          break;
+		case YM2149_LPF_FILTER_LPF_STF: sample = LowPassFilter ( sample );    break;
+		case YM2149_LPF_FILTER_PWM:     sample = PWMaliasFilter ( sample );   break;
+		case YM2149_LPF_FILTER_IIR:     sample = IIRLowPassFilter ( sample ); break;
+	}
+	return sample;
 }
 
 


### PR DESCRIPTION
I had created [an atari-forum thread](https://www.atari-forum.com/viewtopic.php?p=449695) to mention this issue but I just noticed that Hatari has a github mirror, so I've decided to present it as a pull request here.

This PR addresses two issues.

### Issue 1: Lowpass Filter Samplerate

When the sound emulation was updated to work with an internal 250 kHz buffer, the lowpass filters which were designed with coefficients for audio-output samplerate frequencies were not updated and are now operating at a much higher frequency.

The result is that the lowpass filter is effectively disabled, by having a cutoff that's about 5x too high, above the range of hearing. There is a lot of undesirable high frequency noise/aliasing in Hatari's current audio output.

The fix for this is straightforward. In `sound.c` I moved the application of the lowpass filters into `YM2149_NextSample_250`, which is where Hatari downsamples the 250 kHz into the audio output samplerate. The filters now function as they did before here.

### Issue 2: Lowpass Filter Quality

The second problem is that the existing `LowPassFilter` and `PWMaliasPassFilter` (current default) both produces an extremely distorted sound due to the nature of their implementation.

The comments attached to them indicate that they may have some theoretical basis in modelling an asymmetrical push-pull amplifier circuit in the ST. However, the resulting sound is extremely harsh and distorted. I have compared Hatari's output against many recordings of real ST hardware (my own and others) and I do not feel that it accurately matches any of them. It is much more distorted.

There may exist real hardware that does sound this distorted, but in my experience this sound is not representative, and furthermore it is unpleasant and drastically reduces the quality of the audio in Hatari.

1. Provide a new default lowpass filter `IIRLowPassFilter` which gives a simpler symmetrical IIR, applying the same cutoff frequency as one of the two phases of `PWMaliasPassFilter` without the discontinuity of switching between two different phases. The result is a normal, clean sounding, standard lowpass filter effect.

2. Add `YmLpf` and `YmHpf` to the configuration set, so that users can select which of the existing Lowpass or Highpass filters should be used. We are already selecting them in software, but it was never exposed to the user. This allows anyone who prefers a past behaviour to select it instead of the default in their configuration files.
  * `YmLpf` settings:
    * `0 = YM2149_LPF_FILTER_NONE` - Reproduces the current behaviour of a disabled lowpass.
    * `1 = YM2149_LPF_FILTER_LPF_STF` - An older LPF used before PWM became the default?
    * `2 = YM2149_LPF_FILTER_PWM` - The current default.
    * `3 = YM2149_LPF_FILTER_IIR` - The new default, a clean lowpass filter.
  * `YmHpf` settings:
    * `0 = YM2149_HPF_FILTER_NONE` - Disable the highpass.
    * `1 = YM2149_HPF_FILTER_IIR` - The default.

The existing highpass filter was not affected by the samplerate problem, as it was already being applied at the audio samplerate.