### PR TITLE
Fix keymappings for -_ [{ ]} and ~

### DIFF
--- a/src/keymap.c
+++ b/src/keymap.c
@@ -102,7 +102,7 @@ static uint8_t Keymap_SymbolicToStScanCode(const SDL_Keysym* pKeySym)
 	 case SDLK_RIGHTBRACKET: code = 0x1B; break;
 	 case SDLK_CARET: code = 0x2B; break;
 	 case SDLK_UNDERSCORE: code = 0x0C; break;
-	 case SDLK_BACKQUOTE: code = 0x52; break;
+	 case SDLK_BACKQUOTE: code = 0x29; break;
 	 case SDLK_a: code = 0x1E; break;
 	 case SDLK_b: code = 0x30; break;
 	 case SDLK_c: code = 0x2E; break;

--- a/src/keymap.c
+++ b/src/keymap.c
@@ -77,7 +77,7 @@ static uint8_t Keymap_SymbolicToStScanCode(const SDL_Keysym* pKeySym)
 	 case SDLK_ASTERISK: code = 0x66; break;
 	 case SDLK_PLUS: code = 0x1B; break;
 	 case SDLK_COMMA: code = 0x33; break;
-	 case SDLK_MINUS: code = 0x35; break;
+	 case SDLK_MINUS: code = 0x0C; break;
 	 case SDLK_PERIOD: code = 0x34; break;
 	 case SDLK_SLASH: code = 0x35; break;
 	 case SDLK_0: code = 0x0B; break;
@@ -97,9 +97,9 @@ static uint8_t Keymap_SymbolicToStScanCode(const SDL_Keysym* pKeySym)
 	 case SDLK_GREATER : code = 0x34; break;
 	 case SDLK_QUESTION: code = 0x35; break;
 	 case SDLK_AT: code = 0x28; break;
-	 case SDLK_LEFTBRACKET: code = 0x63; break;
+	 case SDLK_LEFTBRACKET: code = 0x1A; break;
 	 case SDLK_BACKSLASH: code = 0x2B; break;     /* Might be 0x60 for UK keyboards */
-	 case SDLK_RIGHTBRACKET: code = 0x64; break;
+	 case SDLK_RIGHTBRACKET: code = 0x1B; break;
 	 case SDLK_CARET: code = 0x2B; break;
 	 case SDLK_UNDERSCORE: code = 0x0C; break;
 	 case SDLK_BACKQUOTE: code = 0x52; break;


### PR DESCRIPTION
There are 3 keys that are un-typable with the current keymap:
* `-`/`_` scancode 0x0C - SDLK_MINUS
* `[`/`{` scancode 0x1A - SDLK_LEFTBRACKET
* `]`/`}` scancode 0x1B - SDLK_RIGHTBRACKET

SDLK_MINUS was mapped to redundantly `/`/`?` and the two brackets were mistakenly mapped as parentheses `(` and `)` instead. I couldn't find any way to type these 3 keys before this change.

Edit: Found one more:
* back quote / `~` scancode 0x29 - SDLK_BACKQUOTE

BACKQUOTE had been mapped to the Insert key instead.