### PR TITLE
Fix drive LED restore logic (glitched LED appearance after resolution change)

### DIFF
--- a/src/statusbar.c
+++ b/src/statusbar.c
@@ -273,10 +273,10 @@ static void Statusbar_OverlayInit(const SDL_Surface *surf)
 	OverlayLedRect.x = surf->w - 5*h/2;
 	OverlayLedRect.y = h/2;
 	/* free previous restore surface if it's incompatible */
-	if (OverlayUnderside &&
-	    OverlayUnderside->w == OverlayLedRect.w &&
-	    OverlayUnderside->h == OverlayLedRect.h &&
-	    OverlayUnderside->format->BitsPerPixel == surf->format->BitsPerPixel)
+	if (OverlayUnderside && (
+	    OverlayUnderside->w != OverlayLedRect.w &&
+	    OverlayUnderside->h != OverlayLedRect.h &&
+	    OverlayUnderside->format->BitsPerPixel != surf->format->BitsPerPixel))
 	{
 		SDL_FreeSurface(OverlayUnderside);
 		OverlayUnderside = NULL;

--- a/src/statusbar.c
+++ b/src/statusbar.c
@@ -274,8 +274,8 @@ static void Statusbar_OverlayInit(const SDL_Surface *surf)
 	OverlayLedRect.y = h/2;
 	/* free previous restore surface if it's incompatible */
 	if (OverlayUnderside && (
-	    OverlayUnderside->w != OverlayLedRect.w &&
-	    OverlayUnderside->h != OverlayLedRect.h &&
+	    OverlayUnderside->w != OverlayLedRect.w ||
+	    OverlayUnderside->h != OverlayLedRect.h ||
 	    OverlayUnderside->format->BitsPerPixel != surf->format->BitsPerPixel))
 	{
 		SDL_FreeSurface(OverlayUnderside);


### PR DESCRIPTION
`OverlayUnderside` is supposed to free itself when the resolution changes and the  buffer no longer matches the new LED overlay size, but the logic to test if the surface is incompatible was backwards.

The effect was that the LED may restore the background underneath only partially when there has been a resolution change. Usually it would look like a chunk was taken out of the corner of it.

I believe SDL's blit clipping kept the memory safe from corruption, at least, but might as well fix it.