### PR TITLE
Add unit test build product to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ src/cpu/gencpu
 tests/debugger/test-breakcond
 tests/debugger/test-evaluate
 tests/debugger/test-symbols
+tests/unit/test-file
 
 tools/hmsa/hmsa
 tools/debugger/gst2ascii


### PR DESCRIPTION
The unit test build creates an executable, `tests/unit/test-file`, that should not be committed.  This pull requests adds that file to `.gitignore`.

After `./configure; make`, without the patch:

```
wayne@mercury:~/lab/hatari/hatari$ git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

        tests/unit/test-file
```
