### PR TITLE
Symbolic map of SDLK_MINUS should use US minus scancode

### DIFF
--- a/src/keymap.c
+++ b/src/keymap.c
@@ -77,7 +77,7 @@ static uint8_t Keymap_SymbolicToStScanCode(const SDL_Keysym* pKeySym)
 	 case SDLK_ASTERISK: code = 0x66; break;
 	 case SDLK_PLUS: code = 0x1B; break;
 	 case SDLK_COMMA: code = 0x33; break;
-	 case SDLK_MINUS: code = 0x35; break;
+	 case SDLK_MINUS: code = 0x0C; break;
 	 case SDLK_PERIOD: code = 0x34; break;
 	 case SDLK_SLASH: code = 0x35; break;
 	 case SDLK_0: code = 0x0B; break;


### PR DESCRIPTION
This was part of #26 but rejected. I would like to re-propose it with a better explanation. (Apologies that this re-iterates [post close comments](https://github.com/hatari/hatari/pull/26#issuecomment-1694765677) on that PR.)

The default "Symbolic" key-mappings give 100% coverage of the US layout keyboard to US TOS, except for this one key.

There are several keys not on a US keyboard that are also provided some mapping, since they don't conflict, but the mapping here is [explicitly QWERTY](https://github.com/hatari/hatari/blob/868189bb0aa60cccb9b6b3fc45ed600c675929c6/src/keymap.c#L55) according to the comment just above it.

This change was rejected in PR #26 because it conflicts with the German mapping, but I believe that all of the default Symbolic mappings conflict with the German mapping where different than US layout, not just this one. Therefore I propose this key should use the US mapping, so that at least one layout 100% works with the default.

It seems that with default Symbolic settings with German host keyboard + German TOS we already have many mapping conflicts with the default keys, notably Y vs Z but many other places. Am I correct in believing this? I don't think it makes sense to cause SDLK_MINUS to work as expected for this case in only German, but have all its other mappings still wrong.

(I don't have a physical German keyboard to compare, though I can set my keyboard layout in Windows, and the results are what I'd expect to see given the code. Does what I describe match the behaviour with the physical keyboard as well?)