### PR TITLE
Use ST palette for PNG screenshots if possible

### DIFF
--- a/src/avi_record.c
+++ b/src/avi_record.c
@@ -95,7 +95,6 @@ const char AVIRecord_fileid[] = "Hatari avi_record.c";
 #include "sound.h"
 #include "statusbar.h"
 #include "avi_record.h"
-#include "video.h"
 
 /* after above that brings in config.h */
 #if HAVE_LIBPNG

--- a/src/avi_record.c
+++ b/src/avi_record.c
@@ -95,6 +95,7 @@ const char AVIRecord_fileid[] = "Hatari avi_record.c";
 #include "sound.h"
 #include "statusbar.h"
 #include "avi_record.h"
+#include "video.h"
 
 /* after above that brings in config.h */
 #if HAVE_LIBPNG

--- a/src/includes/pixel_convert.h
+++ b/src/includes/pixel_convert.h
@@ -50,20 +50,20 @@ static inline void PixelConvert_32to24Bits(Uint8 *dst, Uint32 *src, int dw, SDL_
 }
 
 /**
- * Revert 16-bit RGBA pixels to 16-color ST palette if possible, false if failed.
+ * Remap 16-bit RGBA pixels back to 16-color ST palette if possible, false if failed.
  * Note that this cannot disambiguate indices if the palette has duplicate colors.
  */
 static inline bool PixelConvert_16to8Bits(Uint8 *dst, Uint16 *src, int dw, SDL_Surface *surf)
 {
 	Uint16 sval;
-	Uint8 dval;
+	int dval;
 	int i,dx;
 	bool valid = true;
 	
 	for (dx = 0; dx < dw; dx++)
 	{
 		sval = src[(dx * surf->w + dw/2) / dw];
-		dval = 255;
+		dval = ConvertPaletteSize;
 		for (i = 0; i < ConvertPaletteSize; i++)
 		{
 			if (sval == ConvertPalette[i])
@@ -77,26 +77,26 @@ static inline bool PixelConvert_16to8Bits(Uint8 *dst, Uint16 *src, int dw, SDL_S
 			valid = false;
 			dval = 0;
 		}
-		*dst++ = dval;
+		*dst++ = (Uint8)dval;
 	}
 	return valid;
 }
 
 /**
- *  unpack 32-bit RGBA pixels to 16-color ST palette if possible, false if failed.
+ * Remap 32-bit RGBA pixels back to 16-color ST palette if possible, false if failed.
  * Note that this cannot disambiguate indices if the palette has duplicate colors.
  */
 static inline bool PixelConvert_32to8Bits(Uint8 *dst, Uint32 *src, int dw, SDL_Surface *surf)
 {
 	Uint32 sval;
-	Uint8 dval;
+	int dval;
 	int i,dx;
 	bool valid = true;
 
 	for (dx = 0; dx < dw; dx++)
 	{
 		sval = src[(dx * surf->w + dw/2) / dw];
-		dval = 255;
+		dval = ConvertPaletteSize;
 		for (i = 0; i < ConvertPaletteSize; i++)
 		{
 			if (sval == ConvertPalette[i])
@@ -110,7 +110,7 @@ static inline bool PixelConvert_32to8Bits(Uint8 *dst, Uint32 *src, int dw, SDL_S
 			valid = false;
 			dval = 0;
 		}
-		*dst++ = dval;
+		*dst++ = (Uint8)dval;
 	}
 	return valid;
 }

--- a/src/includes/pixel_convert.h
+++ b/src/includes/pixel_convert.h
@@ -59,12 +59,15 @@ static inline bool PixelConvert_16to8Bits(Uint8 *dst, Uint16 *src, int dw, SDL_S
 	Uint8 dval;
 	int i,dx;
 	bool valid = true;
+	int count = 16;
+	if (STRes == ST_MEDIUM_RES)
+		count = 4;
 
 	for (dx = 0; dx < dw; dx++)
 	{
 		sval = src[(dx * surf->w + dw/2) / dw];
 		dval = 255;
-		for (i = 0; i < 16; i++)
+		for (i = 0; i < count; i++)
 		{
 			if (sval == STRGBPalette[i])
 			{
@@ -72,7 +75,7 @@ static inline bool PixelConvert_16to8Bits(Uint8 *dst, Uint16 *src, int dw, SDL_S
 				break;
 			}
 		}
-		if (dval >= 16)
+		if (dval >= count)
 		{
 			valid = false;
 			dval = 0;
@@ -92,12 +95,15 @@ static inline bool PixelConvert_32to8Bits(Uint8 *dst, Uint32 *src, int dw, SDL_S
 	Uint8 dval;
 	int i,dx;
 	bool valid = true;
+	int count = 16;
+	if (STRes == ST_MEDIUM_RES)
+		count = 4;
 
 	for (dx = 0; dx < dw; dx++)
 	{
 		sval = src[(dx * surf->w + dw/2) / dw];
 		dval = 255;
-		for (i = 0; i < 16; i++)
+		for (i = 0; i < count; i++)
 		{
 			if (sval == STRGBPalette[i])
 			{
@@ -105,7 +111,7 @@ static inline bool PixelConvert_32to8Bits(Uint8 *dst, Uint32 *src, int dw, SDL_S
 				break;
 			}
 		}
-		if (dval >= 16)
+		if (dval >= count)
 		{
 			valid = false;
 			dval = 0;

--- a/src/includes/pixel_convert.h
+++ b/src/includes/pixel_convert.h
@@ -49,6 +49,71 @@ static inline void PixelConvert_32to24Bits(Uint8 *dst, Uint32 *src, int dw, SDL_
 	}
 }
 
+/**
+ * Revert 16-bit RGBA pixels to 16-color ST palette if possible, false if failed.
+ * Note that this cannot disambiguate indices if the palette has duplicate colors.
+ */
+static inline bool PixelConvert_16to8Bits(Uint8 *dst, Uint16 *src, int dw, SDL_Surface *surf)
+{
+	Uint16 sval;
+	Uint8 dval;
+	int i,dx;
+	bool valid = true;
+
+	for (dx = 0; dx < dw; dx++)
+	{
+		sval = src[(dx * surf->w + dw/2) / dw];
+		dval = 255;
+		for (i = 0; i < 16; i++)
+		{
+			if (sval == STRGBPalette[i])
+			{
+				dval = i;
+				break;
+			}
+		}
+		if (dval >= 16)
+		{
+			valid = false;
+			dval = 0;
+		}
+		*dst++ = dval;
+	}
+	return valid;
+}
+
+/**
+ *  unpack 32-bit RGBA pixels to 16-color ST palette if possible, false if failed.
+ * Note that this cannot disambiguate indices if the palette has duplicate colors.
+ */
+static inline bool PixelConvert_32to8Bits(Uint8 *dst, Uint32 *src, int dw, SDL_Surface *surf)
+{
+	Uint32 sval;
+	Uint8 dval;
+	int i,dx;
+	bool valid = true;
+
+	for (dx = 0; dx < dw; dx++)
+	{
+		sval = src[(dx * surf->w + dw/2) / dw];
+		dval = 255;
+		for (i = 0; i < 16; i++)
+		{
+			if (sval == STRGBPalette[i])
+			{
+				dval = i;
+				break;
+			}
+		}
+		if (dval >= 16)
+		{
+			valid = false;
+			dval = 0;
+		}
+		*dst++ = dval;
+	}
+	return valid;
+}
 
 
 /*----------------------------------------------------------------------*/

--- a/src/includes/pixel_convert.h
+++ b/src/includes/pixel_convert.h
@@ -59,23 +59,20 @@ static inline bool PixelConvert_16to8Bits(Uint8 *dst, Uint16 *src, int dw, SDL_S
 	Uint8 dval;
 	int i,dx;
 	bool valid = true;
-	int count = 16;
-	if (STRes == ST_MEDIUM_RES)
-		count = 4;
-
+	
 	for (dx = 0; dx < dw; dx++)
 	{
 		sval = src[(dx * surf->w + dw/2) / dw];
 		dval = 255;
-		for (i = 0; i < count; i++)
+		for (i = 0; i < ConvertPaletteSize; i++)
 		{
-			if (sval == STRGBPalette[i])
+			if (sval == ConvertPalette[i])
 			{
 				dval = i;
 				break;
 			}
 		}
-		if (dval >= count)
+		if (dval >= ConvertPaletteSize)
 		{
 			valid = false;
 			dval = 0;
@@ -95,23 +92,20 @@ static inline bool PixelConvert_32to8Bits(Uint8 *dst, Uint32 *src, int dw, SDL_S
 	Uint8 dval;
 	int i,dx;
 	bool valid = true;
-	int count = 16;
-	if (STRes == ST_MEDIUM_RES)
-		count = 4;
 
 	for (dx = 0; dx < dw; dx++)
 	{
 		sval = src[(dx * surf->w + dw/2) / dw];
 		dval = 255;
-		for (i = 0; i < count; i++)
+		for (i = 0; i < ConvertPaletteSize; i++)
 		{
-			if (sval == STRGBPalette[i])
+			if (sval == ConvertPalette[i])
 			{
 				dval = i;
 				break;
 			}
 		}
-		if (dval >= count)
+		if (dval >= ConvertPaletteSize)
 		{
 			valid = false;
 			dval = 0;

--- a/src/includes/screen.h
+++ b/src/includes/screen.h
@@ -92,6 +92,9 @@ extern Uint8 *pSTScreen;
 extern SDL_Surface *sdlscrn;
 extern Uint32 STRGBPalette[16];
 extern Uint32 ST2RGB[4096];
+extern Uint32* ConvertPalette;
+extern int ConvertPaletteSize;
+
 
 extern uint16_t HBLPalettes[HBL_PALETTE_LINES];
 extern uint16_t *pHBLPalettes;

--- a/src/screen.c
+++ b/src/screen.c
@@ -76,6 +76,10 @@ Uint32 ST2RGB[4096];          /* Table to convert ST 0x777 / STe 0xfff palette t
 Uint8 *pSTScreen;
 FRAMEBUFFER *pFrameBuffer;    /* Pointer into current 'FrameBuffer' */
 
+/* extern for screen snapshot palettes */
+Uint32* ConvertPalette = STRGBPalette;
+int ConvertPaletteSize = 0;
+
 uint16_t HBLPalettes[HBL_PALETTE_LINES];          /* 1x16 colour palette per screen line, +1 line just in case write after line 200 */
 uint16_t *pHBLPalettes;                           /* Pointer to current palette lists, one per HBL */
 uint32_t HBLPaletteMasks[HBL_PALETTE_MASKS];      /* Bit mask of palette colours changes, top bit set is resolution change */
@@ -1263,6 +1267,11 @@ static bool Screen_DrawFrame(bool bForceFlip)
 		Screen_SetFullUpdateMask();
 		bPrevFrameWasSpec512 = false;
 	}
+
+	/* store palette fore screenshots.
+	 * pDrawFunction may override this if it calls Screen_GenConvert */
+	ConvertPalette = STRGBPalette;
+	ConvertPaletteSize = (STRes == ST_MEDIUM_RES) ? 4 : 16;
 
 	if (pDrawFunction)
 		CALL_VAR(pDrawFunction);

--- a/src/screen.c
+++ b/src/screen.c
@@ -1268,7 +1268,7 @@ static bool Screen_DrawFrame(bool bForceFlip)
 		bPrevFrameWasSpec512 = false;
 	}
 
-	/* store palette fore screenshots.
+	/* store palette for screenshots.
 	 * pDrawFunction may override this if it calls Screen_GenConvert */
 	ConvertPalette = STRGBPalette;
 	ConvertPaletteSize = (STRes == ST_MEDIUM_RES) ? 4 : 16;

--- a/src/screenConvert.c
+++ b/src/screenConvert.c
@@ -682,6 +682,12 @@ void Screen_GenConvert(uint32_t vaddr, void *fvram, int vw, int vh,
 {
 	nScreenBaseAddr = vaddr;
 
+	/* Override drawing palette for screenshots. */
+	ConvertPalette = palette.native;
+	ConvertPaletteSize = 1 << vbpp;
+	if (ConvertPaletteSize > 256)
+		ConvertPaletteSize = 256;
+
 	if (nScreenZoomX * nScreenZoomY != 1) {
 		Screen_ConvertWithZoom(fvram, vw, vh, vbpp, nextline, hscroll,
 		                       leftBorderSize, rightBorderSize,

--- a/src/screenSnapShot.c
+++ b/src/screenSnapShot.c
@@ -122,6 +122,7 @@ int ScreenSnapShot_SavePNG_ToFile(SDL_Surface *surface, int dw, int dh,
 	bool do_palette = true;
 	png_color png_pal[16];
 	Uint8 palbuf[3];
+	int palcount = 16;
 
 	if (!dw)
 		dw = sw;
@@ -206,8 +207,10 @@ int ScreenSnapShot_SavePNG_ToFile(SDL_Surface *surface, int dw, int dh,
 
 	if (do_palette)
 	{
-		/* Convert STR palette */
-		for (y = 0; y < 16; y++)
+		/* Convert ST palette */
+		if (STRes == ST_MEDIUM_RES)
+			palcount = 4;
+		for (y = 0; y < palcount; y++)
 		{
 			switch (fmt->BytesPerPixel)
 			{
@@ -224,7 +227,7 @@ int ScreenSnapShot_SavePNG_ToFile(SDL_Surface *surface, int dw, int dh,
 			png_pal[y].green = palbuf[1];
 			png_pal[y].blue  = palbuf[2];
 		}
-		png_set_PLTE(png_ptr, info_ptr, png_pal, 16);
+		png_set_PLTE(png_ptr, info_ptr, png_pal, palcount);
 	}
 
 	/* write the file header information */

--- a/src/screenSnapShot.c
+++ b/src/screenSnapShot.c
@@ -118,8 +118,10 @@ int ScreenSnapShot_SavePNG_ToFile(SDL_Surface *surface, int dw, int dh,
 	png_text pngtext;
 	char key[] = "Title";
 	char text[] = "Hatari screenshot";
-	off_t start;;
-
+	off_t start;
+	bool do_palette = true;
+	png_color png_pal[16];
+	Uint8 palbuf[3];
 
 	if (!dw)
 		dw = sw;
@@ -127,6 +129,32 @@ int ScreenSnapShot_SavePNG_ToFile(SDL_Surface *surface, int dw, int dh,
 		dh = sh;
 
 	rowbuf = alloca(3 * dw);
+
+	/* Use current ST palette if all colours in the image belong to it. */
+	do_lock = SDL_MUSTLOCK(surface);
+	if (do_lock)
+		SDL_LockSurface(surface);
+	for (y = 0; y < dh; y++)
+	{
+		src_ptr = (Uint8 *)surface->pixels
+		          + (CropTop + (y * sh + dh/2) / dh) * surface->pitch
+		          + CropLeft * surface->format->BytesPerPixel;
+		switch (fmt->BytesPerPixel)
+		{
+		 case 2:
+			if (!PixelConvert_16to8Bits(rowbuf, (Uint16*)src_ptr, dw, surface))
+				do_palette = false;
+			break;
+		 case 4:
+			if (!PixelConvert_32to8Bits(rowbuf, (Uint32*)src_ptr, dw, surface))
+				do_palette = false;
+			break;
+		 default:
+			abort();
+		}
+	}
+	if (do_lock)
+		SDL_UnlockSurface(surface);
 
 	/* Create and initialize the png_struct with error handler functions. */
 	png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
@@ -157,7 +185,8 @@ int ScreenSnapShot_SavePNG_ToFile(SDL_Surface *surface, int dw, int dh,
 	png_init_io(png_ptr, fp);
 
 	/* image data properties */
-	png_set_IHDR(png_ptr, info_ptr, dw, dh, 8, PNG_COLOR_TYPE_RGB,
+	png_set_IHDR(png_ptr, info_ptr, dw, dh, 8,
+		     do_palette ? PNG_COLOR_TYPE_PALETTE : PNG_COLOR_TYPE_RGB,
 		     PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT,
 		     PNG_FILTER_TYPE_DEFAULT);
 
@@ -175,6 +204,29 @@ int ScreenSnapShot_SavePNG_ToFile(SDL_Surface *surface, int dw, int dh,
 #endif
 	png_set_text(png_ptr, info_ptr, &pngtext, 1);
 
+	if (do_palette)
+	{
+		/* Convert STR palette */
+		for (y = 0; y < 16; y++)
+		{
+			switch (fmt->BytesPerPixel)
+			{
+			 case 2:
+				PixelConvert_16to24Bits(palbuf, (Uint16*)(STRGBPalette+y), 1, surface);
+				break;
+			 case 4:
+				PixelConvert_32to24Bits(palbuf, (Uint32*)(STRGBPalette+y), 1, surface);
+				break;
+			 default:
+				abort();
+			}
+			png_pal[y].red   = palbuf[0];
+			png_pal[y].green = palbuf[1];
+			png_pal[y].blue  = palbuf[2];
+		}
+		png_set_PLTE(png_ptr, info_ptr, png_pal, 16);
+	}
+
 	/* write the file header information */
 	png_write_info(png_ptr, info_ptr);
 
@@ -191,18 +243,37 @@ int ScreenSnapShot_SavePNG_ToFile(SDL_Surface *surface, int dw, int dh,
 		          + (CropTop + (y * sh + dh/2) / dh) * surface->pitch
 		          + CropLeft * surface->format->BytesPerPixel;
 
-		switch (fmt->BytesPerPixel)
+		if (!do_palette)
 		{
-		 case 2:
-			/* unpack 16-bit RGB pixels */
-			PixelConvert_16to24Bits(rowbuf, (Uint16*)src_ptr, dw, surface);
-			break;
-		 case 4:
-			/* unpack 32-bit RGBA pixels */
-			PixelConvert_32to24Bits(rowbuf, (Uint32*)src_ptr, dw, surface);
-			break;
-		 default:
-			abort();
+			switch (fmt->BytesPerPixel)
+			{
+			 case 2:
+				/* unpack 16-bit RGB pixels */
+				PixelConvert_16to24Bits(rowbuf, (Uint16*)src_ptr, dw, surface);
+				break;
+			 case 4:
+				/* unpack 32-bit RGBA pixels */
+				PixelConvert_32to24Bits(rowbuf, (Uint32*)src_ptr, dw, surface);
+				break;
+			 default:
+				abort();
+			}
+		}
+		else
+		{
+			/* Reindex back to ST palette. */
+			/* Note that this cannot disambiguate indices if the palette has duplicate colors. */
+			switch (fmt->BytesPerPixel)
+			{
+			 case 2:
+				PixelConvert_16to8Bits(rowbuf, (Uint16*)src_ptr, dw, surface);
+				break;
+			 case 4:
+				PixelConvert_32to8Bits(rowbuf, (Uint32*)src_ptr, dw, surface);
+				break;
+			 default:
+				abort();
+			}
 		}
 		/* and unlock surface before syscalls */
 		if (do_lock)

--- a/src/screenSnapShot.c
+++ b/src/screenSnapShot.c
@@ -134,7 +134,7 @@ int ScreenSnapShot_SavePNG_ToFile(SDL_Surface *surface, int dw, int dh,
 	do_lock = SDL_MUSTLOCK(surface);
 	if (do_lock)
 		SDL_LockSurface(surface);
-	for (y = 0; y < dh; y++)
+	for (y = 0; y < dh && do_palette; y++)
 	{
 		src_ptr = (Uint8 *)surface->pixels
 		          + (CropTop + (y * sh + dh/2) / dh) * surface->pitch


### PR DESCRIPTION
Tried this out in response to a discussion from the mailing list. It allows PNG screenshots to use the ST palette where possible.

A palettized image has a few advantages. The file size is slightly smaller. Any graphics program that can view the palette can now be used to see what the ST's 16-colour palette looked like at the time of screenshot. It makes palette-based editing of the image easier (e.g. changing colours). Conversion into an ST-ready image format is also more straightforward.

This automatically falls back to a full RGB image if the image contains any colours outside the current ST palette. This means that modes with more colours, or mid-screen palette changes will still produce valid screenshots as full RGB.

In the case where the palette has multiple colours that are identical, they will all be remapped to the first colour with that index. So, if all 16 colours are unique, it will be a 1:1 mapping to the ST in-memory image, but if there is ambiguity it will still show the correct colour, just with potentially the wrong index. A "perfect" version would maybe use the current video memory contents to disambiguate this case, but that would be a bit more complicated to accomplish. This PR instead does the best it can with only the output image and current known palette.