### PR TITLE
NEO direct video memory dump option for screen snapshot

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -97,6 +97,7 @@ static const struct Config_Tag configs_Screen[] =
 	{ "nMaxHeight", Int_Tag, &ConfigureParams.Screen.nMaxHeight },
 	{ "nZoomFactor", Float_Tag, &ConfigureParams.Screen.nZoomFactor },
 	{ "bUseSdlRenderer", Bool_Tag, &ConfigureParams.Screen.bUseSdlRenderer },
+	{ "bNEOScreenSnapShot", Bool_Tag, &ConfigureParams.Screen.bNEOScreenSnapShot },
 	{ "bUseVsync", Bool_Tag, &ConfigureParams.Screen.bUseVsync },
 	{ NULL , Error_Tag, NULL }
 };
@@ -741,6 +742,7 @@ void Configuration_SetDefault(void)
 	ConfigureParams.Screen.nZoomFactor = 1.0;
 	ConfigureParams.Screen.bUseSdlRenderer = true;
 	ConfigureParams.Screen.bUseVsync = false;
+	ConfigureParams.Screen.bNEOScreenSnapShot = false;
 
 	/* Set defaults for Sound */
 	ConfigureParams.Sound.bEnableMicrophone = true;

--- a/src/includes/configuration.h
+++ b/src/includes/configuration.h
@@ -306,6 +306,7 @@ typedef struct
   bool bResizable;
   bool bUseVsync;
   bool bUseSdlRenderer;
+  bool bNEOScreenSnapShot;
   float nZoomFactor;
   int nSpec512Threshold;
   int nVdiColors;

--- a/src/includes/screen.h
+++ b/src/includes/screen.h
@@ -115,6 +115,5 @@ extern void Screen_SetGenConvSize(int width, int height, bool bForceChange);
 extern void Screen_GenConvUpdate(SDL_Rect *extra, bool forced);
 extern Uint32 Screen_GetGenConvWidth(void);
 extern Uint32 Screen_GetGenConvHeight(void);
-extern bool Screen_UseGenConvScreen(void);
 
 #endif  /* ifndef HATARI_SCREEN_H */

--- a/src/includes/screen.h
+++ b/src/includes/screen.h
@@ -115,5 +115,6 @@ extern void Screen_SetGenConvSize(int width, int height, bool bForceChange);
 extern void Screen_GenConvUpdate(SDL_Rect *extra, bool forced);
 extern Uint32 Screen_GetGenConvWidth(void);
 extern Uint32 Screen_GetGenConvHeight(void);
+extern bool Screen_UseGenConvScreen(void);
 
 #endif  /* ifndef HATARI_SCREEN_H */

--- a/src/includes/screen.h
+++ b/src/includes/screen.h
@@ -97,6 +97,7 @@ extern uint16_t HBLPalettes[HBL_PALETTE_LINES];
 extern uint16_t *pHBLPalettes;
 extern uint32_t HBLPaletteMasks[HBL_PALETTE_MASKS];
 extern uint32_t *pHBLPaletteMasks;
+extern int STScreenLineOffset[NUM_VISIBLE_LINES];
 
 extern void Screen_Init(void);
 extern void Screen_UnInit(void);

--- a/src/includes/screenConvert.h
+++ b/src/includes/screenConvert.h
@@ -7,6 +7,7 @@
 
 void Screen_RemapPalette(void);
 void Screen_SetPaletteColor(Uint8 idx, Uint8 red, Uint8 green, Uint8 blue);
+SDL_Color Screen_GetPaletteColor(Uint8 idx);
 void ScreenConv_MemorySnapShot_Capture(bool bSave);
 
 void Screen_GenConvert(uint32_t vaddr, void *fvram, int vw, int vh,

--- a/src/includes/screenConvert.h
+++ b/src/includes/screenConvert.h
@@ -5,6 +5,9 @@
   or at your option any later version. Read the file gpl.txt for details.
 */
 
+/* Last used vw/vh/vbpp for Screen_GenConvert */
+extern int ConvertW, ConvertH, ConvertBPP;
+
 void Screen_RemapPalette(void);
 void Screen_SetPaletteColor(Uint8 idx, Uint8 red, Uint8 green, Uint8 blue);
 SDL_Color Screen_GetPaletteColor(Uint8 idx);

--- a/src/screen.c
+++ b/src/screen.c
@@ -266,7 +266,7 @@ static void Screen_SetSTScreenOffsets(void)
  * Return true if Falcon/TT/VDI generic screen convert functions
  * need to be used instead of the ST/STE functions.
  */
-bool Screen_UseGenConvScreen(void)
+static bool Screen_UseGenConvScreen(void)
 {
 	return Config_IsMachineFalcon() || Config_IsMachineTT()
 		|| bUseHighRes || bUseVDIRes;

--- a/src/screen.c
+++ b/src/screen.c
@@ -266,7 +266,7 @@ static void Screen_SetSTScreenOffsets(void)
  * Return true if Falcon/TT/VDI generic screen convert functions
  * need to be used instead of the ST/STE functions.
  */
-static bool Screen_UseGenConvScreen(void)
+bool Screen_UseGenConvScreen(void)
 {
 	return Config_IsMachineFalcon() || Config_IsMachineTT()
 		|| bUseHighRes || bUseVDIRes;

--- a/src/screen.c
+++ b/src/screen.c
@@ -92,7 +92,7 @@ static int PCScreenOffsetX;         /* how many pixels to skip from left when dr
 static int PCScreenOffsetY;         /* how many pixels to skip from top when drawing */
 static SDL_Rect STScreenRect;       /* screen size without statusbar */
 
-static int STScreenLineOffset[NUM_VISIBLE_LINES];  /* Offsets for ST screen lines eg, 0,160,320... */
+int STScreenLineOffset[NUM_VISIBLE_LINES];         /* Offsets for ST screen lines eg, 0,160,320... */
 static Uint16 HBLPalette[16], PrevHBLPalette[16];  /* Current palette for line, also copy of first line */
 
 static void (*ScreenDrawFunctionsNormal[3])(void); /* Screen draw functions */
@@ -748,6 +748,8 @@ void Screen_UnInit(void)
 	/* Free memory used for copies */
 	free(FrameBuffer.pSTScreen);
 	free(FrameBuffer.pSTScreenCopy);
+	FrameBuffer.pSTScreen = NULL;
+	FrameBuffer.pSTScreenCopy = NULL;
 
 	Screen_FreeSDL2Resources();
 	if (sdlWindow)

--- a/src/screenConvert.c
+++ b/src/screenConvert.c
@@ -31,7 +31,9 @@ static struct screen_zoom_s screen_zoom;
 static bool bTTSampleHold = false;		/* TT special video mode */
 static int nSampleHoldIdx;
 static uint32_t nScreenBaseAddr;		/* address of screen in STRam */
-
+int ConvertW = 0;
+int ConvertH = 0;
+int ConvertBPP = 1;
 
 /* TOS palette (bpp < 16) to SDL color mapping */
 static struct
@@ -686,6 +688,9 @@ void Screen_GenConvert(uint32_t vaddr, void *fvram, int vw, int vh,
                        int upperBorderSize, int lowerBorderSize)
 {
 	nScreenBaseAddr = vaddr;
+	ConvertW = vw;
+	ConvertH = vh;
+	ConvertBPP = vbpp;
 
 	if (nScreenZoomX * nScreenZoomY != 1) {
 		Screen_ConvertWithZoom(fvram, vw, vh, vbpp, nextline, hscroll,

--- a/src/screenConvert.c
+++ b/src/screenConvert.c
@@ -50,6 +50,11 @@ void Screen_SetPaletteColor(Uint8 idx, Uint8 red, Uint8 green, Uint8 blue)
 	palette.native[idx] = SDL_MapRGB(sdlscrn->format, red, green, blue);
 }
 
+SDL_Color Screen_GetPaletteColor(Uint8 idx)
+{
+	return palette.standard[idx];
+}
+
 void Screen_RemapPalette(void)
 {
 	int i;

--- a/src/screenSnapShot.c
+++ b/src/screenSnapShot.c
@@ -29,6 +29,7 @@ const char ScreenSnapShot_fileid[] = "Hatari screenSnapShot.c";
 
 
 static int nScreenShots = 0;                /* Number of screen shots saved */
+static Uint8 NEOHeader[128];
 
 
 /*-----------------------------------------------------------------------*/
@@ -222,6 +223,58 @@ png_cleanup:
 }
 #endif
 
+/**
+ * Helper for writing NEO file header.
+ */
+static void StoreU16NEO(Uint16 val, int offset)
+{
+	NEOHeader[offset+0] = (val >> 8) & 0xFF;
+	NEOHeader[offset+1] = (val >> 0) & 0xFF;
+}
+
+/**
+ * Save direct video memory dump to NEO file.
+ */
+static int ScreenSnapShot_SaveNEO(const char *filename)
+{
+	FILE *fp = NULL;
+	int i, res, sw, sh, stride, offset;
+
+	if (pFrameBuffer == NULL || pFrameBuffer->pSTScreen == NULL)
+		return -1;
+
+	fp = fopen(filename, "wb");
+	if (!fp)
+		return -1;
+
+	res = (STRes == ST_HIGH_RES) ? 2 :
+	      (STRes == ST_MEDIUM_RES) ? 1 :
+	      0;
+	sw = (res > 0) ? 640 : 320;
+	sh = (res > 1) ? 400 : 200;
+	stride = (res > 1) ? 80 : 160;
+
+	memset(NEOHeader, 0, sizeof(NEOHeader));
+	StoreU16NEO(res, 2);
+	for (i=0; i<16; i++) /* Use last line's palette for whole image. */
+		StoreU16NEO(pFrameBuffer->HBLPalettes[i+((OVERSCAN_TOP+sh-1)<<4)], 4+(2*i));
+	memcpy(NEOHeader+36,"        .   ",12);
+	StoreU16NEO(sw, 58);
+	StoreU16NEO(sh, 60);
+
+	fwrite(NEOHeader, 1, 128, fp);
+	for (i = 0; i < sh; i++)
+	{
+		offset = (res > 1) ?
+			(SCREENBYTES_MONOLINE * i) :
+			(STScreenLineOffset[i+OVERSCAN_TOP] + SCREENBYTES_LEFT);
+		fwrite(pFrameBuffer->pSTScreen + offset, 1, stride, fp);
+	}
+
+	fclose (fp);
+	return 1; /* >0 if OK, -1 if error */
+}
+
 
 /*-----------------------------------------------------------------------*/
 /**
@@ -238,6 +291,17 @@ void ScreenSnapShot_SaveScreen(void)
 	ScreenSnapShot_GetNum();
 	/* Create our filename */
 	nScreenShots++;
+	/* NEO memory dump */
+	if (ConfigureParams.Screen.bNEOScreenSnapShot)
+	{
+		sprintf(szFileName,"%s/grab%4.4d.neo", Paths_GetScreenShotDir(), nScreenShots);
+		if (ScreenSnapShot_SaveNEO(szFileName) > 0)
+			fprintf(stderr, "Screen dump saved to: %s\n", szFileName);
+		else
+			fprintf(stderr, "NEO screen dump failed!\n");
+		free(szFileName);
+		return;
+	}
 #if HAVE_LIBPNG
 	/* try first PNG */
 	sprintf(szFileName,"%s/grab%4.4d.png", Paths_GetScreenShotDir(), nScreenShots);
@@ -279,6 +343,11 @@ void ScreenSnapShot_SaveToFile(const char *szFileName)
 	if (File_DoesFileExtensionMatch(szFileName, ".bmp"))
 	{
 		success = SDL_SaveBMP(sdlscrn, szFileName) == 0;
+	}
+	else
+	if (File_DoesFileExtensionMatch(szFileName, ".neo"))
+	{
+		success = ScreenSnapShot_SaveNEO(szFileName) == 0;
 	}
 	else
 	{

--- a/src/screenSnapShot.c
+++ b/src/screenSnapShot.c
@@ -304,8 +304,9 @@ static int ScreenSnapShot_SaveNEO(const char *filename)
 				4+(2*i));
 		}
 	}
-	memcpy(NEOHeader+36,"4BPP  HATARI",12);
-	NEOHeader[36+0] = '0' + bpp; /* Use internal filename to give a hint about bitplanes. */
+	memcpy(NEOHeader+36,"HATARI  4BPP",12); /* Use internal filename to give a hint about bitplanes. */
+	NEOHeader[36+8] = '0' + (bpp % 10);
+	if (bpp >= 10) NEOHeader[36+7] = '0' + (bpp / 10);
 	StoreU16NEO(sw, 58);
 	StoreU16NEO(sh, 60);
 
@@ -336,6 +337,19 @@ static int ScreenSnapShot_SaveNEO(const char *filename)
 		{
 			fclose(fp);
 			return -1;
+		}
+
+		/* Extended RGB palette added as a suffix, in case needed. */
+		if (bpp <= 8 && (bpp > 4 || !Config_IsMachineST()))
+		{
+			fwrite("RGB",1,3,fp);
+			for (i=0; i < (1 << bpp); i++)
+			{
+				col = Screen_GetPaletteColor(i);
+				fwrite(&col.r, 1, 1, fp);
+				fwrite(&col.g, 1, 1, fp);
+				fwrite(&col.b, 1, 1, fp);
+			}
 		}
 	}
 

--- a/src/screenSnapShot.c
+++ b/src/screenSnapShot.c
@@ -256,8 +256,12 @@ static int ScreenSnapShot_SaveNEO(const char *filename)
 
 	memset(NEOHeader, 0, sizeof(NEOHeader));
 	StoreU16NEO(res, 2);
-	for (i=0; i<16; i++) /* Use last line's palette for whole image. */
-		StoreU16NEO(pFrameBuffer->HBLPalettes[i+((OVERSCAN_TOP+sh-1)<<4)], 4+(2*i));
+	/* Use middle line's palette for whole image.
+	 * High resolution does not update HBLPalettes, so its palette data isn't available,
+	 * but access could be added via Video_CopyScreenLineMono or Video_ColorReg_WriteWord? (video.c) */
+	offset = (res > 1) ? 0 : OVERSCAN_TOP;
+	for (i=0; i<16; i++)
+		StoreU16NEO(pFrameBuffer->HBLPalettes[i+((offset+sh/2)<<4)], 4+(2*i));
 	memcpy(NEOHeader+36,"        .   ",12);
 	StoreU16NEO(sw, 58);
 	StoreU16NEO(sh, 60);


### PR DESCRIPTION
An alternative screenshot option based on a recent mailing list discussion.

Enabled via `Config.bNEOScreenSnapShot` (no UI added for it).

This creates a NEO file format screenshot, out of the data in `FrameBuffer` (screen.c). This works for ST low, medium, and high resolutions.

Otherwise with TT or Falcon the `FrameBuffer` structure is not filled with any screen data, so it instead dumps data from ST RAM at the current video base address.

The palette is taken from the centre line of the `FrameBuffer` for Low and Medium resolutions. High resolution and TT/Falcon don't seem to store per-line palette, but I instead extracted the GenConvert palette for it.

Some notes about [the .NEO format](https://www.fileformat.info/format/atari/egff.htm):
* The original NEOChrome program only works with 320x200 4bpp images, though the format has a few header fields that can support other resolutions.
* There are 3 known resolution values (0=low, 1=med, 2=high). This dump will use one of those 3 values if the data is 4, 2, or 1bpp. As an extension for resolutions with different bpp, I have simply placed the bpp value here to assist identification.
* The internal filename starts with "HATARI" and ends with BPP indicator text (e.g. "4BPP"), which can be used to identify the format extension if needed, and as a hint about the BPP.
* The 16 palette entries in the header will be filled with up to 16 x 9-bit colour values in the standard ST format (or STE 12-bit values). If the machine is not an ST and BPP <= 8, a suffix of 2^bpp x 24-bit RGB palette entries will follow the video data to allow a full recovery of the image's original colour. This suffix will begin with 3 ASCII characters "RGB" for verification. (This suffix is ignored by NEOChrome, so 4bpp 320x200 images will a suffix are still compatible.)
* The screen width and height fields are used, indicating the screen dimensions without borders.
* The amount of data that follows the header will match the screen width, height, and bpp.